### PR TITLE
Update to Twitch API v5

### DIFF
--- a/src/.vscode/launch.json
+++ b/src/.vscode/launch.json
@@ -7,7 +7,7 @@
             "request": "launch",
             "reAttach": true,
             "addonType": "addonSdk",
-            "addonPath": "${workspaceRoot}"
+            "addonPath": "${workspaceRoot}",
         }
     ]
 }

--- a/src/background/notification_engine.js
+++ b/src/background/notification_engine.js
@@ -69,7 +69,7 @@ var notificationEngine = {
     var uptimeMs = uptimeHelper.getUptimeMs(notification.channelUptime);
     var hyphen = self.determineHyphen(uptimeMs);
     
-    return `Channel ${notif.channelName} ${hyphen} live.`;
+    return `Channel ${notification.channelName} ${hyphen} live.`;
   },
 
   buildMessageFew: function(self, notifications) {

--- a/src/background/stream_compilation_handler.js
+++ b/src/background/stream_compilation_handler.js
@@ -66,7 +66,9 @@ let compiledStreams = {
         const sortingDirection = settingsAPI.sorting_direction;
         const sortingField = settingsAPI.sorting_field;
         let compiledStream = compiledStreams.compileStream(streamData);
-        let channelIndex = compiledStreams.streams.findIndex(stream => stream.channelName == compiledStream.channelName);
+        let channelIndex = compiledStreams.streams.findIndex(stream => {
+            return stream.channelName == compiledStream.channelName;
+        });
         if(channelIndex != null && channelIndex >= 0) {
             let oldStreamUuid = compiledStreams.streams[channelIndex].uuid;
             compiledStreams.streams[channelIndex] = compiledStream;
@@ -90,12 +92,15 @@ let compiledStreams = {
         };
     },
     handleStreamRemove: function(streamData) {
-        let channelIndex = compiledStreams.streams.findIndex(stream => stream.channelName == streamData.stream.channel.name);
-        let sortByViewersChannelIndex = this.streamsSortedByViewers.findIndex(stream => stream.channelName == streamData.stream.channel.name);
+        let channelIndex = compiledStreams.streams.findIndex(stream => {
+            return stream.channelName == streamData.stream.channel.name;
+        });
+        let sortByViewersChannelIndex = this.streamsSortedByViewers.findIndex(stream => {
+            return stream.channelName == streamData.stream.channel.name
+        });
         this.streamsSortedByViewers.splice(sortByViewersChannelIndex, 1);
         if(channelIndex != null && channelIndex >= 0) {
-            console.log("Removing stream:");
-            console.log(compiledStreams.streams[channelIndex]);
+            console.log(`Removing stream: ${compiledStreams.streams[channelIndex].channelName}`);
             return {
                 success: true,
                 removedStream: compiledStreams.streams.splice(channelIndex, 1)

--- a/src/browser_action/css/settings.css
+++ b/src/browser_action/css/settings.css
@@ -95,6 +95,11 @@
     font-weight: 400;
 }
 
+#save_button_link.disabled .settings_button {
+    background-color: grey;
+    cursor: default;
+}
+
 .debug_row {
     display: flex;
     font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;

--- a/src/browser_action/live_streams.js
+++ b/src/browser_action/live_streams.js
@@ -112,12 +112,14 @@ function hideThumbnails(streamLinkFrame) {
 function addImageFadeInEffect(tag) {
     let channelImageList = tag.getElementsByClassName("channel_image");
     let channelImage = channelImageList[0];
-    channelImage.onload = (function() {
-        let frameId = tag.id;
-        return () => {
-            changeOpacityFadeIn(frameId);
-        }
-    })();
+    if(channelImage) {
+        channelImage.onload = (function() {
+            let frameId = tag.id;
+            return () => {
+                changeOpacityFadeIn(frameId);
+            }
+        })();
+    }
 }
 
 function getContainer() {
@@ -173,13 +175,14 @@ function updateEventListeners() {
         let link = links[linkIndex];
         let channel_name_list = link.getElementsByClassName("upper_channel_name");
         let channel_name = channel_name_list[0];
-
-        link.onclick = (function() {
-            let local_channel_name = channel_name.innerHTML;
-            return () => {
-                openStream(local_channel_name);
-            }
-        })();
+        if(channel_name) {
+            link.onclick = (function() {
+                let local_channel_name = channel_name.innerHTML;
+                return () => {
+                    openStream(local_channel_name);
+                }
+            })();
+        }
     }
 }
 

--- a/src/browser_action/pages/settings.html
+++ b/src/browser_action/pages/settings.html
@@ -12,6 +12,7 @@
         </div>
         <div class="setting_row" style="margin-bottom: 5px;">
             <input id="user_name" type="text" name="fname">
+            <span style="color: grey; padding: 5px;">UserID: <span id="user_id"></span></span>
         </div>
         <!-- Stream sorting -->
         <p class="settings_section">Live stream list</p>

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "Twitch Streams",
-    "version": "0.7.1",
+    "version": "0.8.0",
     "description": "Twitch followed streams browser, notifier",
 
     "applications": {


### PR DESCRIPTION
Twitch stopped supporting the v3 API, which broke this extension. This PR updates it to use the v5 API. This mostly entails using channel IDs instead of channel names everywhere, and replacing some missing properties used in comparisons with other available ones.

I also added a user ID indicator next to the username input in the settings to indicate a valid username.

Note that Twitch recommends to update to the "New Twitch API" instead of the v5 API, but I didn't want to invest more time than necessary to get this working again. It might be necessary to switch in the near future though.

Fixes issue #1.